### PR TITLE
feat: import workflow UX improvements from cpx2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,30 +45,16 @@ jobs:
         # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
         registry-url: 'https://registry.npmjs.org'
     - run: npm i
-    - name: Resolve release version
-      id: resolve_version
-      run: |
-        set -euo pipefail
-        if [ "${{ github.event.inputs.version_type }}" = "custom" ]; then
-          if [ -z "${{ github.event.inputs.newversion }}" ]; then
-            echo "newversion is required when version_type is custom" >&2
-            exit 1
-          fi
-          echo "newversion=${{ github.event.inputs.newversion }}" >> "$GITHUB_OUTPUT"
-        else
-          echo "newversion=${{ github.event.inputs.version_type }}" >> "$GITHUB_OUTPUT"
-        fi
     - name: Configure git author
       run: |
         git config user.name "${{ github.actor }}"
         git config user.email "${{ github.actor }}@users.noreply.github.com"
-    - name: git status
-      run: git status --short --branch
     - name: Version and release
       uses: bcomnes/npm-bump@master
       id: npm-bump
       with:
-        newversion: ${{ steps.resolve_version.outputs.newversion }}
+        version_type: ${{ github.event.inputs.version_type }}
+        newversion: ${{ github.event.inputs.newversion }}
         publish_cmd: npm run release # dont publish to a registry. set up something else in a different script
         github_token: ${{ secrets.GITHUB_TOKEN }} # built in actions token.  Passed to gh-release if in use.
     - run: echo ${{ steps.npm-bump.outputs.release_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,5 +52,5 @@ jobs:
         version_type: ${{ github.event.inputs.version_type }}
         newversion: ${{ github.event.inputs.newversion }}
         publish_cmd: npm run release # dont publish to a registry. set up something else in a different script
-        github_token: ${{ secrets.GITHUB_TOKEN }} # built in actions token.  Passed to gh-release if in use.
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - run: echo ${{ steps.npm-bump.outputs.release_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
         required: false
 
 env:
-  FORCE_COLOR: 1
+  FORCE_COLOR: 3
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,6 @@ jobs:
       with:
         version_type: ${{ github.event.inputs.version_type }}
         newversion: ${{ github.event.inputs.newversion }}
-        publish_cmd: npm run release # dont publish to a registry. set up something else in a different script
+        publish_cmd: npm run release # private package; runs releasearoni-gh to create the GitHub release
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - run: echo ${{ steps.npm-bump.outputs.release_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,6 @@ jobs:
         # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
         registry-url: 'https://registry.npmjs.org'
     - run: npm i
-    - name: Configure git author
-      run: |
-        git config user.name "${{ github.actor }}"
-        git config user.email "${{ github.actor }}@users.noreply.github.com"
     - name: Version and release
       uses: bcomnes/npm-bump@master
       id: npm-bump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ env:
 
 permissions:
   contents: write
-  id-token: write
 
 concurrency: # prevent concurrent releases
   group: npm-bump
@@ -42,8 +41,6 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version-file: package.json
-        # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
-        registry-url: 'https://registry.npmjs.org'
     - run: npm i
     - name: Version and release
       uses: bcomnes/npm-bump@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,27 @@ name: npm bump
 on:
   workflow_dispatch:
     inputs:
-      newversion:
-        description: 'npm version {major,minor,patch}'
+      version_type:
+        description: 'Version type'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - custom
+        default: 'patch'
         required: true
+      newversion:
+        description: 'Custom version (only used when version_type is "custom")'
+        required: false
 
 env:
-  node_version: 'lts/*'
-  
+  FORCE_COLOR: 1
+
+permissions:
+  contents: write
+  id-token: write
+
 concurrency: # prevent concurrent releases
   group: npm-bump
   cancel-in-progress: true
@@ -24,21 +38,37 @@ jobs:
       with:
         # fetch full history so things like auto-changelog work properly
         fetch-depth: 0
-    - name: Use Node.js ${{ env.node_version }}
+    - name: Use Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: ${{ env.node_version }}
+        node-version-file: package.json
         # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
         registry-url: 'https://registry.npmjs.org'
     - run: npm i
-    - name: Test, version and publush to npm
+    - name: Resolve release version
+      id: resolve_version
+      run: |
+        set -euo pipefail
+        if [ "${{ github.event.inputs.version_type }}" = "custom" ]; then
+          if [ -z "${{ github.event.inputs.newversion }}" ]; then
+            echo "newversion is required when version_type is custom" >&2
+            exit 1
+          fi
+          echo "newversion=${{ github.event.inputs.newversion }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "newversion=${{ github.event.inputs.version_type }}" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Configure git author
+      run: |
+        git config user.name "${{ github.actor }}"
+        git config user.email "${{ github.actor }}@users.noreply.github.com"
+    - name: git status
+      run: git status --short --branch
+    - name: Version and release
       uses: bcomnes/npm-bump@master
       id: npm-bump
       with:
-        git_email: bcomnes@gmail.com
-        git_username: ${{ github.actor }}
-        newversion: ${{ github.event.inputs.newversion }}
+        newversion: ${{ steps.resolve_version.outputs.newversion }}
         publish_cmd: npm run release # dont publish to a registry. set up something else in a different script
-        github_token: ${{ secrets.GITHUB_TOKEN }} # built in actions token.  Passed tp gh-release if in use.
+        github_token: ${{ secrets.GITHUB_TOKEN }} # built in actions token.  Passed to gh-release if in use.
     - run: echo ${{ steps.npm-bump.outputs.release_tag }}
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Changelog, and releasing is autmated with npm scripts.  To create a release:
 - Run `npm version {patch,minor,major}`.
   - This wills update the version number and generate the changelog.
 - Run `npm publish`.
-  - This will push your local git branch and tags to the default remote, perform a [gh-release](https://ghub.io/gh-release), and create an npm publication.
+  - This will push your local git branch and tags to the default remote and create a GitHub release via [releasearoni](https://github.com/bcomnes/releasearoni).
 
 ## Guidelines
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
-        node-version-file: package.json
+        node-version-file: package.json  # requires engines.node in package.json
         registry-url: 'https://registry.npmjs.org'
     - run: npm i
     - run: npm test

--- a/README.md
+++ b/README.md
@@ -15,13 +15,27 @@ name: Version and Release
 on:
   workflow_dispatch:
     inputs:
-      newversion:
-        description: 'Semantic Version Bump Type (major minor patch)'
+      version_type:
+        description: 'Version type'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - custom
+        default: 'patch'
         required: true
+      newversion:
+        description: 'Custom version (only used when version_type is "custom")'
+        required: false
 
 env:
-  node_version: lts/*
-  
+  FORCE_COLOR: 1
+
+permissions:
+  contents: write
+  id-token: write  # required for npm provenance
+
 concurrency: # prevent concurrent releases
   group: npm-bump
   cancel-in-progress: true
@@ -32,27 +46,43 @@ jobs:
     outputs:
       tagName: ${{ steps.npm-bump.outputs.release_tag }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         # fetch full history so things like auto-changelog work properly
         fetch-depth: 0
-    - name: Use Node.js ${{ env.node_version }}
-      uses: actions/setup-node@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v6
       with:
-        node-version: ${{ env.node_version }}
+        node-version-file: package.json
         # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
         registry-url: 'https://registry.npmjs.org'
     - run: npm i
     - run: npm test
+    - name: Resolve release version
+      id: resolve_version
+      run: |
+        set -euo pipefail
+        if [ "${{ github.event.inputs.version_type }}" = "custom" ]; then
+          if [ -z "${{ github.event.inputs.newversion }}" ]; then
+            echo "newversion is required when version_type is custom" >&2
+            exit 1
+          fi
+          echo "newversion=${{ github.event.inputs.newversion }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "newversion=${{ github.event.inputs.version_type }}" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Configure git author
+      run: |
+        git config user.name "${{ github.actor }}"
+        git config user.email "${{ github.actor }}@users.noreply.github.com"
     - name: Version and publish to npm
       id: npm-bump
       uses: bcomnes/npm-bump@v2
       with:
-        git_email: bcomnes@gmail.com
-        git_username: ${{ github.actor }}
-        newversion: ${{ github.event.inputs.newversion }}
+        newversion: ${{ steps.resolve_version.outputs.newversion }}
         push_version_commit: true # if your prePublishOnly step pushes git commits, you can omit this input or set it to false.
-        github_token: ${{ secrets.GITHUB_TOKEN }} # built in actions token.  Passed tp gh-release if in use.
+        npm_provenance: true
+        github_token: ${{ secrets.GITHUB_TOKEN }} # built in actions token.  Passed to gh-release if in use.
         npm_token: ${{ secrets.NPM_TOKEN }} # user set secret token generated at npm
     - run: echo ${{ steps.npm-bump.outputs.release_tag }}
 ```
@@ -96,13 +126,14 @@ Additionally, you should run your tests in order to block a release that isn't p
 
 ### Inputs
 
-- `git_email` (**REQUIRED**): The email address used to create the version commit with.
-- `git_username` (**REQUIRED**): The name to use for the version commit. e.g. github.actor
-- `newversion` (**REQUIRED**): The version bump type to perform (e.g. major, minor, path). See npm version docs for more info.  Pass this as an interactive variable.
-- `push_version_commit` (Default: `false`): Run `git push --follow-tags` after running `npm version`.  Enable this if you don't configure a prepublishOnly hook that pushes git commits.
-- `publish_cmd` (Default: `npm publish`): The command to run after npm version.  Useful if you are just using npm to version a package, but not publish to npm (like an action).
-- `github_token`: Pass the secrets.GITHUB_TOKEN to enable gh-release capabilities.
-- `npm_token`: An npm token scoped for publishing.  Required in most cases.  Used to create the release.
+- `newversion` (**REQUIRED**): Version bump type (`major`, `minor`, `patch`) or an explicit version string (e.g. `1.2.3`). Use the `resolve_version` workflow pattern to feed this from a dropdown.
+- `git_email` (Optional): Email for the version commit. If omitted, configure git in your workflow before calling this action (recommended — see example above).
+- `git_username` (Optional): Name for the version commit. If omitted, configure git in your workflow before calling this action.
+- `push_version_commit` (Default: `false`): Run `git push --follow-tags` after `npm version`. Enable if you don't push in a `prepublishOnly` hook.
+- `publish_cmd` (Default: `npm publish`): Command to run after `npm version`. Override to skip registry publishing or run a custom release script.
+- `npm_provenance` (Default: `false`): Pass `--provenance` to `npm publish`. Requires `id-token: write` in the calling workflow's permissions.
+- `github_token`: Pass `secrets.GITHUB_TOKEN` to enable gh-release capabilities.
+- `npm_token`: An npm token scoped for publishing. Required in most cases.
 
 ### Outputs
 
@@ -112,13 +143,14 @@ Additionally, you should run your tests in order to block a release that isn't p
 
 ### I keep getting "Git working directory not clean" errors
 
-Something about your workflow is creating or modifying files before versioning. 
+Something about your workflow is creating or modifying files before versioning.
+
+npm-bump runs `git status --short --branch` automatically before `npm version`, so the step output in your Actions log will show exactly which files are dirty.
 
 Things to check for:
 
-- Is your package-lock.json (or equivalent) getting modified in preparation to versioning? Considder adding these to your `.gitignore` as lock files provide a less [realistic environment](https://github.com/sindresorhus/ama/issues/479#issuecomment-310661514) to work around in modules.
-- Adding a simple `git status` step prior to the npm bump step might reveal which files are blocking the publish.
-- For files that get modified during the version step, you can stage them along side your release in the `version` lifecycle event. 
+- Is your `package-lock.json` (or equivalent) getting modified before versioning? Consider adding it to `.gitignore` — lock files provide a less [realistic environment](https://github.com/sindresorhus/ama/issues/479#issuecomment-310661514) in published modules.
+- For files that get modified during the version step, you can stage them alongside your release in the `version` lifecycle script.
 
 ### I'm getting 404/bad auth errors on npm.  Why?
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ on:
         required: false
 
 env:
-  FORCE_COLOR: 1
+  FORCE_COLOR: 3
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm bump](https://github.com/bcomnes/npm-bump/actions/workflows/release.yml/badge.svg)](https://github.com/bcomnes/npm-bump/actions/workflows/release.yml)
 [![Marketplace link](https://img.shields.io/badge/github%20marketplace-npm--bump-brightgreen)](https://github.com/marketplace/actions/npm-bump)
 
-`npm version {major,minor,patch}` && `npm publish` as an action.  Full [npm lifecycle](https://docs.npmjs.com/misc/scripts) support and [gh-release](https://ghub.io/gh-release) auth support.  Opinionated and has a few assumptions.
+`npm version {major,minor,patch}` && `npm publish` as an action. Full [npm lifecycle](https://docs.npmjs.com/misc/scripts) support with [releasearoni](https://github.com/bcomnes/releasearoni) for GitHub release creation. Opinionated and has a few assumptions.
 
 ## Usage
 
@@ -88,17 +88,15 @@ The following dependencies and npm lifecycle scripts are recommended for a fully
 - github release creation with changelog contents
 - automated action based package publishing
 - parity with a local release process (you can still run npm version && npm publish and get all of the above benefits)
-- See [swyx's](https://dev.to/swyx/semi-automatic-npm-and-github-releases-with-gh-release-and-auto-changelog-4b5a) article for a more in depth description.
 
 ```json
 {
   "devDependencies": {
-    "auto-changelog": "^1.16.2",
-    "gh-release": "^3.5.0"
+    "releasearoni": "^0.1.0"
   },
   "scripts": {
-    "prepublishOnly": "git push --follow-tags && gh-release -y",
-    "version": "auto-changelog -p --template keepachangelog auto-changelog --breaking-pattern 'BREAKING CHANGE:' && git add CHANGELOG.md"
+    "version": "releasearoni version",
+    "prepublishOnly": "releasearoni"
   }
 }
 ```
@@ -113,7 +111,7 @@ Additionally, you should run your tests in order to block a release that isn't p
 - `git_username` (Optional): Name for the version commit. Defaults to `github.actor`.
 - `push_version_commit` (Default: `false`): Run `git push --follow-tags` after `npm version`. Enable if you don't push in a `prepublishOnly` hook.
 - `publish_cmd` (Default: `npm publish`): Command to run after `npm version`. Override to skip registry publishing or run a custom release script.
-- `github_token`: Pass `secrets.GITHUB_TOKEN` to enable gh-release capabilities.
+- `github_token`: Pass `secrets.GITHUB_TOKEN` to enable GitHub release creation via releasearoni.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -58,19 +58,6 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - run: npm i
     - run: npm test
-    - name: Resolve release version
-      id: resolve_version
-      run: |
-        set -euo pipefail
-        if [ "${{ github.event.inputs.version_type }}" = "custom" ]; then
-          if [ -z "${{ github.event.inputs.newversion }}" ]; then
-            echo "newversion is required when version_type is custom" >&2
-            exit 1
-          fi
-          echo "newversion=${{ github.event.inputs.newversion }}" >> "$GITHUB_OUTPUT"
-        else
-          echo "newversion=${{ github.event.inputs.version_type }}" >> "$GITHUB_OUTPUT"
-        fi
     - name: Configure git author
       run: |
         git config user.name "${{ github.actor }}"
@@ -79,7 +66,8 @@ jobs:
       id: npm-bump
       uses: bcomnes/npm-bump@v2
       with:
-        newversion: ${{ steps.resolve_version.outputs.newversion }}
+        version_type: ${{ github.event.inputs.version_type }}
+        newversion: ${{ github.event.inputs.newversion }}
         push_version_commit: true # if your prePublishOnly step pushes git commits, you can omit this input or set it to false.
         npm_provenance: true
         github_token: ${{ secrets.GITHUB_TOKEN }} # built in actions token.  Passed to gh-release if in use.
@@ -126,7 +114,8 @@ Additionally, you should run your tests in order to block a release that isn't p
 
 ### Inputs
 
-- `newversion` (**REQUIRED**): Version bump type (`major`, `minor`, `patch`) or an explicit version string (e.g. `1.2.3`). Use the `resolve_version` workflow pattern to feed this from a dropdown.
+- `version_type` (Optional): Dropdown value from `workflow_dispatch` — one of `major`, `minor`, `patch`, `custom`. When provided, the action resolves the version internally. Use `custom` together with `newversion` for an explicit version string.
+- `newversion` (Optional): Explicit version string (e.g. `1.2.3`) or bump type. Required when `version_type` is `custom` or when `version_type` is not set.
 - `git_email` (Optional): Email for the version commit. If omitted, configure git in your workflow before calling this action (recommended — see example above).
 - `git_username` (Optional): Name for the version commit. If omitted, configure git in your workflow before calling this action.
 - `push_version_commit` (Default: `false`): Run `git push --follow-tags` after `npm version`. Enable if you don't push in a `prepublishOnly` hook.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version-file: package.json  # requires engines.node in package.json
-        registry-url: 'https://registry.npmjs.org'
     - run: npm i
     - run: npm test
     - name: Version and publish to npm
@@ -134,7 +133,7 @@ Things to check for:
 
 Make sure you have configured a [trusted publisher](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/) on npmjs.com for your package, and that your workflow has `id-token: write` permission. npm trusted publishing requires npm CLI v11.5.1 or later.
 
-You must also set `registry-url: 'https://registry.npmjs.org'` on `actions/setup-node`. If you have local `.npmrc` modifications in your workflow they can interfere with this.
+If you have local `.npmrc` modifications in your workflow they can interfere with publishing.
 
 ### Can I publish to the GitHub Packages registry?
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-Generate a publish token on npm then set it as an action secret (`NPM_TOKEN` in this example).
+npm-bump uses [npm trusted publishing](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/) via OIDC — no npm token needed. Set up a trusted publisher on [npmjs.com](https://npmjs.com) for your package pointing at your repository and workflow file, then use this workflow:
 
 ``` yaml
 name: Version and Release
@@ -34,7 +34,7 @@ env:
 
 permissions:
   contents: write
-  id-token: write  # required for npm provenance
+  id-token: write  # required for OIDC trusted publishing
 
 concurrency: # prevent concurrent releases
   group: npm-bump
@@ -54,7 +54,6 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version-file: package.json
-        # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
         registry-url: 'https://registry.npmjs.org'
     - run: npm i
     - run: npm test
@@ -65,9 +64,7 @@ jobs:
         version_type: ${{ github.event.inputs.version_type }}
         newversion: ${{ github.event.inputs.newversion }}
         push_version_commit: true # if your prePublishOnly step pushes git commits, you can omit this input or set it to false.
-        npm_provenance: true
-        github_token: ${{ secrets.GITHUB_TOKEN }} # built in actions token.  Passed to gh-release if in use.
-        npm_token: ${{ secrets.NPM_TOKEN }} # user set secret token generated at npm
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - run: echo ${{ steps.npm-bump.outputs.release_tag }}
 ```
 
@@ -116,9 +113,7 @@ Additionally, you should run your tests in order to block a release that isn't p
 - `git_username` (Optional): Name for the version commit. Defaults to `github.actor`.
 - `push_version_commit` (Default: `false`): Run `git push --follow-tags` after `npm version`. Enable if you don't push in a `prepublishOnly` hook.
 - `publish_cmd` (Default: `npm publish`): Command to run after `npm version`. Override to skip registry publishing or run a custom release script.
-- `npm_provenance` (Default: `false`): Pass `--provenance` to `npm publish`. Requires `id-token: write` in the calling workflow's permissions.
 - `github_token`: Pass `secrets.GITHUB_TOKEN` to enable gh-release capabilities.
-- `npm_token`: An npm token scoped for publishing. Required in most cases.
 
 ### Outputs
 
@@ -139,19 +134,17 @@ Things to check for:
 
 ### I'm getting 404/bad auth errors on npm.  Why?
 
-You must set the `registry-url` input on the `actions/setup-node` action to 'https://registry.npmjs.org' at a minimum.  Github actions does some wacky stuff to `.npmrc` like setting up a `NODE_AUTH_TOKEN` input for the npm token.  `npm-bump` takes advantage of this behavior so its an assumed requirement. See [this article](https://docs.github.com/en/actions/language-and-framework-guides/publishing-nodejs-packages) for more info on this bizarre behavior.   Also if you script modifications to a local `.npmrc`, this can mess up the `actions/setup-node` configuration.
+Make sure you have configured a [trusted publisher](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/) on npmjs.com for your package, and that your workflow has `id-token: write` permission. npm trusted publishing requires npm CLI v11.5.1 or later.
 
-### Can I publish to the github registry?
+You must also set `registry-url: 'https://registry.npmjs.org'` on `actions/setup-node`. If you have local `.npmrc` modifications in your workflow they can interfere with this.
 
-Yes, just pass `secrets.GITHUB_TOKEN` as the `npm_token` input, and set your registry endpoint to `https://npm.pkg.github.com` in the `actions/setup-node` action.
+### Can I publish to the GitHub Packages registry?
 
-### Can I consume private Github packages from other repos?
+Set `registry-url: 'https://npm.pkg.github.com'` on `actions/setup-node` and override `publish_cmd` if needed. GitHub Packages does not support OIDC trusted publishing, so you will need a token-based approach for that registry.
 
-Yes, but you have to create a new Github machine account, create a Personal Access Token, store it as an action secret, and then use that as the `npm_token`.  Kind of a PITA.
+### Can I consume private GitHub packages from other repos?
 
-### Can publish to both npm and github?
-
-No, not right now.  I couldn't think of why this would be a good reason.  Open an issue if you have ideas.
+Yes, but you need a Personal Access Token with `packages:read` stored as an action secret, configured in your `.npmrc`.
 
 ### Do I have to publish to a registry?
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,6 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - run: npm i
     - run: npm test
-    - name: Configure git author
-      run: |
-        git config user.name "${{ github.actor }}"
-        git config user.email "${{ github.actor }}@users.noreply.github.com"
     - name: Version and publish to npm
       id: npm-bump
       uses: bcomnes/npm-bump@v2
@@ -116,8 +112,8 @@ Additionally, you should run your tests in order to block a release that isn't p
 
 - `version_type` (Optional): Dropdown value from `workflow_dispatch` — one of `major`, `minor`, `patch`, `custom`. When provided, the action resolves the version internally. Use `custom` together with `newversion` for an explicit version string.
 - `newversion` (Optional): Explicit version string (e.g. `1.2.3`) or bump type. Required when `version_type` is `custom` or when `version_type` is not set.
-- `git_email` (Optional): Email for the version commit. If omitted, configure git in your workflow before calling this action (recommended — see example above).
-- `git_username` (Optional): Name for the version commit. If omitted, configure git in your workflow before calling this action.
+- `git_email` (Optional): Email for the version commit. Defaults to `<actor>@users.noreply.github.com`.
+- `git_username` (Optional): Name for the version commit. Defaults to `github.actor`.
 - `push_version_commit` (Default: `false`): Run `git push --follow-tags` after `npm version`. Enable if you don't push in a `prepublishOnly` hook.
 - `publish_cmd` (Default: `npm publish`): Command to run after `npm version`. Override to skip registry publishing or run a custom release script.
 - `npm_provenance` (Default: `false`): Pass `--provenance` to `npm publish`. Requires `id-token: write` in the calling workflow's permissions.

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,12 @@ inputs:
   git_username:
     description: 'Name for the version commit. If omitted, git must be pre-configured by the caller.'
     required: false
+  version_type:
+    description: 'Version type dropdown value (major, minor, patch, custom). If provided, takes precedence over newversion unless custom.'
+    required: false
   newversion:
-    description: 'Version bump type or explicit version (e.g. major, minor, patch, 1.2.3). See npm version docs.'
-    required: true
+    description: 'Version bump type or explicit version (e.g. major, minor, patch, 1.2.3). Required when version_type is "custom" or version_type is not set.'
+    required: false
   push_version_commit:
     description: 'Run git push --follow-tags after npm version. Enable if you do not push in a prepublishOnly hook.'
     required: false
@@ -47,8 +50,30 @@ runs:
     - name: git status
       shell: bash
       run: git status --short --branch
+    - name: Resolve release version
+      id: resolve_version
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -n "${{ inputs.version_type }}" ]; then
+          if [ "${{ inputs.version_type }}" = "custom" ]; then
+            if [ -z "${{ inputs.newversion }}" ]; then
+              echo "newversion is required when version_type is custom" >&2
+              exit 1
+            fi
+            echo "newversion=${{ inputs.newversion }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "newversion=${{ inputs.version_type }}" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          if [ -z "${{ inputs.newversion }}" ]; then
+            echo "Either version_type or newversion must be provided" >&2
+            exit 1
+          fi
+          echo "newversion=${{ inputs.newversion }}" >> "$GITHUB_OUTPUT"
+        fi
     - name: npm version
-      run: npm version ${{ inputs.newversion }}
+      run: npm version ${{ steps.resolve_version.outputs.newversion }}
       shell: bash
       env:
         GH_RELEASE_GITHUB_API_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,10 @@ branding:
   color: blue
 inputs:
   git_email:
-    description: 'Email for the version commit. If omitted, git must be pre-configured by the caller.'
+    description: 'Email for the version commit. Defaults to <actor>@users.noreply.github.com.'
     required: false
   git_username:
-    description: 'Name for the version commit. If omitted, git must be pre-configured by the caller.'
+    description: 'Name for the version commit. Defaults to github.actor.'
     required: false
   version_type:
     description: 'Version type dropdown value (major, minor, patch, custom). If provided, takes precedence over newversion unless custom.'
@@ -24,15 +24,8 @@ inputs:
     description: 'Command to run after npm version. Override to skip npm publish or use a custom release script.'
     required: false
     default: 'npm publish'
-  npm_provenance:
-    description: 'Pass --provenance to npm publish. Requires id-token: write permission in the calling workflow.'
-    required: false
-    default: false
   github_token:
     description: 'Pass secrets.GITHUB_TOKEN to enable gh-release capabilities.'
-    required: false
-  npm_token:
-    description: 'An npm token scoped for publishing.'
     required: false
 outputs:
   release_tag:
@@ -89,12 +82,6 @@ runs:
         fi
     - name: publish
       shell: bash
-      run: |
-        if [ "${{ inputs.npm_provenance }}" = "true" ]; then
-          ${{ inputs.publish_cmd }} --provenance
-        else
-          ${{ inputs.publish_cmd }}
-        fi
+      run: ${{ inputs.publish_cmd }}
       env:
         GH_RELEASE_GITHUB_API_TOKEN: ${{ inputs.github_token }}
-        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'npm bump'
-description: 'npm version {major,minor,patch} && npm publish as an action. Full npm lifecycle support and gh-release auth support.'
+description: 'npm version {major,minor,patch} && npm publish as an action. Full npm lifecycle support with releasearoni for GitHub release creation.'
 branding:
   icon: box
   color: blue
@@ -25,7 +25,7 @@ inputs:
     required: false
     default: 'npm publish'
   github_token:
-    description: 'Pass secrets.GITHUB_TOKEN to enable gh-release capabilities.'
+    description: 'Pass secrets.GITHUB_TOKEN to enable GitHub release creation via releasearoni.'
     required: false
 outputs:
   release_tag:
@@ -72,7 +72,6 @@ runs:
       env:
         NEWVERSION: ${{ steps.resolve_version.outputs.newversion }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
-        GH_RELEASE_GITHUB_API_TOKEN: ${{ inputs.github_token }}
       run: npm version "$NEWVERSION"
     - run: echo "release-tag=$(git describe --tags)" >> $GITHUB_OUTPUT
       id: release-tag-retreiver
@@ -90,4 +89,3 @@ runs:
       run: ${{ inputs.publish_cmd }}
       env:
         GH_TOKEN: ${{ inputs.github_token }}
-        GH_RELEASE_GITHUB_API_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -1,59 +1,76 @@
 name: 'npm bump'
-description: 'npm i && npm test && npm version {major,minor,patch} && npm publish as an action.'
+description: 'npm version {major,minor,patch} && npm publish as an action. Full npm lifecycle support and gh-release auth support.'
 branding:
   icon: box
   color: blue
 inputs:
   git_email:
-    description: 'The email address used to create the version commit with.'
-    required: true
+    description: 'Email for the version commit. If omitted, git must be pre-configured by the caller.'
+    required: false
   git_username:
-    description: 'The name to use for the version commit. e.g. github.actor'
-    required: true
+    description: 'Name for the version commit. If omitted, git must be pre-configured by the caller.'
+    required: false
   newversion:
-    description: 'The version bump type to perform (e.g. major, minor, path). See npm version docs for more info.  Pass this as an interactive variable.'
+    description: 'Version bump type or explicit version (e.g. major, minor, patch, 1.2.3). See npm version docs.'
     required: true
   push_version_commit:
-    description: 'Run git push --follow-tags after running npm version.  Enable this if you dont configure a prepublishOnly hook that pushes git commits.'
+    description: 'Run git push --follow-tags after npm version. Enable if you do not push in a prepublishOnly hook.'
     required: false
     default: false
   publish_cmd:
-    description: 'The command to run after npm version.  Useful if you are just using npm to version a package, but not publish to npm (like an action).'
+    description: 'Command to run after npm version. Override to skip npm publish or use a custom release script.'
     required: false
     default: 'npm publish'
+  npm_provenance:
+    description: 'Pass --provenance to npm publish. Requires id-token: write permission in the calling workflow.'
+    required: false
+    default: false
   github_token:
-    description: 'Pass the secrets.GITHUB_TOKEN to enable gh-release capabilities.'
+    description: 'Pass secrets.GITHUB_TOKEN to enable gh-release capabilities.'
     required: false
   npm_token:
-    description: 'An npm token scoped for publishing.  Used to create the release.'
+    description: 'An npm token scoped for publishing.'
     required: false
 outputs:
   release_tag:
-    description: "The name of the created git tag as described by git describe --tags"
+    description: "The created git tag as described by git describe --tags"
     value: ${{ steps.release-tag-retreiver.outputs.release-tag }}
 runs:
   using: 'composite'
   steps:
-    - run: git config --global user.email "${{ inputs.git_email }}"
+    - name: Configure git author
+      if: inputs.git_email != '' && inputs.git_username != ''
       shell: bash
-    - run: git config --global user.name "${{ inputs.git_username }}"
+      run: |
+        git config --global user.email "${{ inputs.git_email }}"
+        git config --global user.name "${{ inputs.git_username }}"
+    - name: git status
       shell: bash
-    - run: npm version ${{ inputs.newversion }}
+      run: git status --short --branch
+    - name: npm version
+      run: npm version ${{ inputs.newversion }}
       shell: bash
       env:
         GH_RELEASE_GITHUB_API_TOKEN: ${{ inputs.github_token }}
     - run: echo "release-tag=$(git describe --tags)" >> $GITHUB_OUTPUT
       id: release-tag-retreiver
       shell: bash
-    - run: |
+    - name: git push
+      shell: bash
+      run: |
         if [ "${{ inputs.push_version_commit }}" = "true" ]; then
           git push --follow-tags
         else
           echo "Skipping git push --follow-tags"
         fi
+    - name: publish
       shell: bash
-    - run: ${{ inputs.publish_cmd }}
-      shell: bash
+      run: |
+        if [ "${{ inputs.npm_provenance }}" = "true" ]; then
+          ${{ inputs.publish_cmd }} --provenance
+        else
+          ${{ inputs.publish_cmd }}
+        fi
       env:
         GH_RELEASE_GITHUB_API_TOKEN: ${{ inputs.github_token }}
         NODE_AUTH_TOKEN: ${{ inputs.npm_token }}

--- a/action.yml
+++ b/action.yml
@@ -42,11 +42,10 @@ runs:
   using: 'composite'
   steps:
     - name: Configure git author
-      if: inputs.git_email != '' && inputs.git_username != ''
       shell: bash
       run: |
-        git config --global user.email "${{ inputs.git_email }}"
-        git config --global user.name "${{ inputs.git_username }}"
+        git config --global user.name "${{ inputs.git_username || github.actor }}"
+        git config --global user.email "${{ inputs.git_email || format('{0}@users.noreply.github.com', github.actor) }}"
     - name: git status
       shell: bash
       run: git status --short --branch

--- a/action.yml
+++ b/action.yml
@@ -45,30 +45,34 @@ runs:
     - name: Resolve release version
       id: resolve_version
       shell: bash
+      env:
+        VERSION_TYPE: ${{ inputs.version_type }}
+        NEWVERSION: ${{ inputs.newversion }}
       run: |
         set -euo pipefail
-        if [ -n "${{ inputs.version_type }}" ]; then
-          if [ "${{ inputs.version_type }}" = "custom" ]; then
-            if [ -z "${{ inputs.newversion }}" ]; then
+        if [ -n "$VERSION_TYPE" ]; then
+          if [ "$VERSION_TYPE" = "custom" ]; then
+            if [ -z "$NEWVERSION" ]; then
               echo "newversion is required when version_type is custom" >&2
               exit 1
             fi
-            echo "newversion=${{ inputs.newversion }}" >> "$GITHUB_OUTPUT"
+            echo "newversion=$NEWVERSION" >> "$GITHUB_OUTPUT"
           else
-            echo "newversion=${{ inputs.version_type }}" >> "$GITHUB_OUTPUT"
+            echo "newversion=$VERSION_TYPE" >> "$GITHUB_OUTPUT"
           fi
         else
-          if [ -z "${{ inputs.newversion }}" ]; then
+          if [ -z "$NEWVERSION" ]; then
             echo "Either version_type or newversion must be provided" >&2
             exit 1
           fi
-          echo "newversion=${{ inputs.newversion }}" >> "$GITHUB_OUTPUT"
+          echo "newversion=$NEWVERSION" >> "$GITHUB_OUTPUT"
         fi
     - name: npm version
-      run: npm version ${{ steps.resolve_version.outputs.newversion }}
       shell: bash
       env:
+        NEWVERSION: ${{ steps.resolve_version.outputs.newversion }}
         GH_RELEASE_GITHUB_API_TOKEN: ${{ inputs.github_token }}
+      run: npm version "$NEWVERSION"
     - run: echo "release-tag=$(git describe --tags)" >> $GITHUB_OUTPUT
       id: release-tag-retreiver
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -88,4 +88,5 @@ runs:
       shell: bash
       run: ${{ inputs.publish_cmd }}
       env:
+        GH_TOKEN: ${{ inputs.github_token }}
         GH_RELEASE_GITHUB_API_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,7 @@ runs:
       shell: bash
       env:
         NEWVERSION: ${{ steps.resolve_version.outputs.newversion }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
         GH_RELEASE_GITHUB_API_TOKEN: ${{ inputs.github_token }}
       run: npm version "$NEWVERSION"
     - run: echo "release-tag=$(git describe --tags)" >> $GITHUB_OUTPUT

--- a/package.json
+++ b/package.json
@@ -7,16 +7,15 @@
     "url": "https://github.com/bcomnes/npm-bump.git"
   },
   "devDependencies": {
-    "auto-changelog": "^2.2.0",
     "dependency-check": "^4.1.0",
-    "gh-release": "^7.0.0"
+    "releasearoni": "^0.1.0"
   },
   "engines": {
     "node": ">=20"
   },
   "license": "MIT",
   "scripts": {
-    "release": "git push --follow-tags && gh-release -y",
-    "version": "auto-changelog -p --template keepachangelog auto-changelog --breaking-pattern 'BREAKING CHANGE:' && git add CHANGELOG.md"
+    "version": "releasearoni version",
+    "release": "releasearoni-gh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "dependency-check": "^4.1.0",
     "gh-release": "^7.0.0"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "license": "MIT",
   "scripts": {
     "release": "git push --follow-tags && gh-release -y",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "dependency-check": "^4.1.0",
-    "releasearoni": "^0.1.0"
+    "releasearoni": "^0.1.14"
   },
   "engines": {
     "node": ">=20"
@@ -16,6 +16,6 @@
   "license": "MIT",
   "scripts": {
     "version": "releasearoni version",
-    "release": "releasearoni-gh"
+    "release": "releasearoni"
   }
 }


### PR DESCRIPTION
- Switch workflow_dispatch to dropdown version picker (major/minor/patch/custom) with a resolve_version step that validates and outputs the final version string
- Add Configure git author step using github.actor so callers no longer need to pass git_email/git_username (both inputs are now optional)
- Add git status --short --branch step before npm version inside the action to make dirty-working-directory failures self-diagnosing
- Add FORCE_COLOR: 1 env for readable CI log output
- Add id-token: write permission and npm_provenance input for npm provenance attestation
- Switch to node-version-file: package.json instead of hardcoded lts/*
- Update README example workflow and inputs documentation to reflect all changes