### PR TITLE
feat: major version branch maintenance + kebab-case input rename (breaking)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: npm bump
 on:
   workflow_dispatch:
     inputs:
-      version_type:
+      version-type:
         description: 'Version type'
         type: choice
         options:
@@ -13,8 +13,8 @@ on:
           - custom
         default: 'patch'
         required: true
-      newversion:
-        description: 'Custom version (only used when version_type is "custom")'
+      new-version:
+        description: 'Custom version (only used when version-type is "custom")'
         required: false
 
 env:
@@ -31,7 +31,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     outputs:
-      tagName: ${{ steps.npm-bump.outputs.release_tag }}
+      tagName: ${{ steps.npm-bump.outputs.release-tag }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -46,8 +46,9 @@ jobs:
       uses: bcomnes/npm-bump@master
       id: npm-bump
       with:
-        version_type: ${{ github.event.inputs.version_type }}
-        newversion: ${{ github.event.inputs.newversion }}
-        publish_cmd: npm run release # private package; runs releasearoni-gh to create the GitHub release
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-    - run: echo ${{ steps.npm-bump.outputs.release_tag }}
+        version-type: ${{ github.event.inputs['version-type'] }}
+        new-version: ${{ github.event.inputs['new-version'] }}
+        publish-cmd: npm run release # private package; runs releasearoni-gh to create the GitHub release
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        major-branch: true
+    - run: echo ${{ steps.npm-bump.outputs['release-tag'] }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ name: Version and Release
 on:
   workflow_dispatch:
     inputs:
-      version_type:
+      version-type:
         description: 'Version type'
         type: choice
         options:
@@ -25,8 +25,8 @@ on:
           - custom
         default: 'patch'
         required: true
-      newversion:
-        description: 'Custom version (only used when version_type is "custom")'
+      new-version:
+        description: 'Custom version (only used when version-type is "custom")'
         required: false
 
 env:
@@ -44,7 +44,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     outputs:
-      tagName: ${{ steps.npm-bump.outputs.release_tag }}
+      tagName: ${{ steps.npm-bump.outputs.release-tag }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -58,13 +58,13 @@ jobs:
     - run: npm test
     - name: Version and publish to npm
       id: npm-bump
-      uses: bcomnes/npm-bump@v2
+      uses: bcomnes/npm-bump@v3
       with:
-        version_type: ${{ github.event.inputs.version_type }}
-        newversion: ${{ github.event.inputs.newversion }}
-        push_version_commit: true # if your prePublishOnly step pushes git commits, you can omit this input or set it to false.
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-    - run: echo ${{ steps.npm-bump.outputs.release_tag }}
+        version-type: ${{ github.event.inputs['version-type'] }}
+        new-version: ${{ github.event.inputs['new-version'] }}
+        push-version-commit: true # if your prePublishOnly step pushes git commits, you can omit this input or set it to false.
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - run: echo ${{ steps.npm-bump.outputs['release-tag'] }}
 ```
 
 This will give you a push-button triggered action that runs `npm version {major,minor,patch}`, `git push --follow-tags` and finally `npm publish`.
@@ -79,7 +79,7 @@ It is advisable to set a `prePublishOnly` lifecycle hook that runs, at a minimum
 }
 ```
 
-With that lifecycle set, you can omit the `push_version_commit` input, or set it to false.
+With that lifecycle set, you can omit the `push-version-commit` input, or set it to false.
 
 The following dependencies and npm lifecycle scripts are recommended for a fully automated release process that includes:
 
@@ -104,17 +104,18 @@ Additionally, you should run your tests in order to block a release that isn't p
 
 ### Inputs
 
-- `version_type` (Optional): Dropdown value from `workflow_dispatch` — one of `major`, `minor`, `patch`, `custom`. When provided, the action resolves the version internally. Use `custom` together with `newversion` for an explicit version string.
-- `newversion` (Optional): Explicit version string (e.g. `1.2.3`) or bump type. Required when `version_type` is `custom` or when `version_type` is not set.
-- `git_email` (Optional): Email for the version commit. Defaults to `<actor>@users.noreply.github.com`.
-- `git_username` (Optional): Name for the version commit. Defaults to `github.actor`.
-- `push_version_commit` (Default: `false`): Run `git push --follow-tags` after `npm version`. Enable if you don't push in a `prepublishOnly` hook.
-- `publish_cmd` (Default: `npm publish`): Command to run after `npm version`. Override to skip registry publishing or run a custom release script.
-- `github_token`: Pass `secrets.GITHUB_TOKEN` to enable GitHub release creation via releasearoni.
+- `version-type` (Optional): Dropdown value from `workflow_dispatch` — one of `major`, `minor`, `patch`, `custom`. When provided, the action resolves the version internally. Use `custom` together with `new-version` for an explicit version string.
+- `new-version` (Optional): Explicit version string (e.g. `1.2.3`) or bump type. Required when `version-type` is `custom` or when `version-type` is not set.
+- `git-email` (Optional): Email for the version commit. Defaults to `<actor>@users.noreply.github.com`.
+- `git-username` (Optional): Name for the version commit. Defaults to `github.actor`.
+- `push-version-commit` (Default: `false`): Run `git push --follow-tags` after `npm version`. Enable if you don't push in a `prepublishOnly` hook.
+- `publish-cmd` (Default: `npm publish`): Command to run after `npm version`. Override to skip registry publishing or run a custom release script.
+- `github-token`: Pass `secrets.GITHUB_TOKEN` to enable GitHub release creation via releasearoni.
+- `major-branch` (Default: `false`): After publishing, create or force-reset a floating major version branch (e.g. `v1`, `v2`) to the release commit and force-push it to origin. Enables consumers to pin to a major version ref (`uses: you/action@v3`) and receive updates automatically. Requires `contents: write` permission.
 
 ### Outputs
 
-- `release_tag`: The name of the created git tag as described by git describe --tags
+- `release-tag`: The name of the created git tag as described by git describe --tags
 
 ## FAQ
 
@@ -126,7 +127,6 @@ npm-bump runs `git status --short --branch` automatically before `npm version`, 
 
 Things to check for:
 
-- Is your `package-lock.json` (or equivalent) getting modified before versioning? Consider adding it to `.gitignore` — lock files provide a less [realistic environment](https://github.com/sindresorhus/ama/issues/479#issuecomment-310661514) in published modules.
 - For files that get modified during the version step, you can stage them alongside your release in the `version` lifecycle script.
 
 ### I'm getting 404/bad auth errors on npm.  Why?
@@ -137,7 +137,7 @@ If you have local `.npmrc` modifications in your workflow they can interfere wit
 
 ### Can I publish to the GitHub Packages registry?
 
-Set `registry-url: 'https://npm.pkg.github.com'` on `actions/setup-node` and override `publish_cmd` if needed. GitHub Packages does not support OIDC trusted publishing, so you will need a token-based approach for that registry.
+Set `registry-url: 'https://npm.pkg.github.com'` on `actions/setup-node` and override `publish-cmd` if needed. GitHub Packages does not support OIDC trusted publishing, so you will need a token-based approach for that registry.
 
 ### Can I consume private GitHub packages from other repos?
 
@@ -149,7 +149,20 @@ Nope, you can completely override the `npm publish` command with whatever you wa
 
 ### Can you offer a major version tag/branch alias?  I want automatic updates!
 
-Yes. npm-bump now offers a major version ref you can install with.
+Yes. Set `major-branch: true` and npm-bump will create or force-reset a branch named after the major version (e.g. `v1`, `v2`, `v3`) and force-push it to origin after every release. Consumers can then reference your action as `uses: you/action@v3` and automatically receive all patch and minor updates within that major version.
+
+```yaml
+    - name: Version and publish to npm
+      uses: bcomnes/npm-bump@v3
+      with:
+        version-type: ${{ github.event.inputs['version-type'] }}
+        new-version: ${{ github.event.inputs['new-version'] }}
+        push-version-commit: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        major-branch: true
+```
+
+The branch is force-pushed, so no history is retained on it — it is purely a floating pointer to the latest release commit for that major version.
 
 ### Why isn't npm-bump running tests anymore?
 

--- a/action.yml
+++ b/action.yml
@@ -4,31 +4,35 @@ branding:
   icon: box
   color: blue
 inputs:
-  git_email:
+  git-email:
     description: 'Email for the version commit. Defaults to <actor>@users.noreply.github.com.'
     required: false
-  git_username:
+  git-username:
     description: 'Name for the version commit. Defaults to github.actor.'
     required: false
-  version_type:
-    description: 'Version type dropdown value (major, minor, patch, custom). If provided, takes precedence over newversion unless custom.'
+  version-type:
+    description: 'Version type dropdown value (major, minor, patch, custom). If provided, takes precedence over new-version unless custom.'
     required: false
-  newversion:
-    description: 'Version bump type or explicit version (e.g. major, minor, patch, 1.2.3). Required when version_type is "custom" or version_type is not set.'
+  new-version:
+    description: 'Version bump type or explicit version (e.g. major, minor, patch, 1.2.3). Required when version-type is "custom" or version-type is not set.'
     required: false
-  push_version_commit:
+  push-version-commit:
     description: 'Run git push --follow-tags after npm version. Enable if you do not push in a prepublishOnly hook.'
     required: false
     default: false
-  publish_cmd:
+  publish-cmd:
     description: 'Command to run after npm version. Override to skip npm publish or use a custom release script.'
     required: false
     default: 'npm publish'
-  github_token:
+  github-token:
     description: 'Pass secrets.GITHUB_TOKEN to enable GitHub release creation via releasearoni.'
     required: false
+  major-branch:
+    description: 'Create or force-reset a major version branch (e.g. v1, v2) to the release commit and force-push it. Required for floating major-version refs in GitHub Actions consumers.'
+    required: false
+    default: false
 outputs:
-  release_tag:
+  release-tag:
     description: "The created git tag as described by git describe --tags"
     value: ${{ steps.release-tag-retreiver.outputs.release-tag }}
 runs:
@@ -37,55 +41,72 @@ runs:
     - name: Configure git author
       shell: bash
       run: |
-        git config --global user.name "${{ inputs.git_username || github.actor }}"
-        git config --global user.email "${{ inputs.git_email || format('{0}@users.noreply.github.com', github.actor) }}"
+        git config --global user.name "${{ inputs['git-username'] || github.actor }}"
+        git config --global user.email "${{ inputs['git-email'] || format('{0}@users.noreply.github.com', github.actor) }}"
     - name: git status
       shell: bash
       run: git status --short --branch
     - name: Resolve release version
-      id: resolve_version
+      id: resolve-version
       shell: bash
       env:
-        VERSION_TYPE: ${{ inputs.version_type }}
-        NEWVERSION: ${{ inputs.newversion }}
+        VERSION_TYPE: ${{ inputs['version-type'] }}
+        NEW_VERSION: ${{ inputs['new-version'] }}
       run: |
         set -euo pipefail
         if [ -n "$VERSION_TYPE" ]; then
           if [ "$VERSION_TYPE" = "custom" ]; then
-            if [ -z "$NEWVERSION" ]; then
-              echo "newversion is required when version_type is custom" >&2
+            if [ -z "$NEW_VERSION" ]; then
+              echo "new-version is required when version-type is custom" >&2
               exit 1
             fi
-            echo "newversion=$NEWVERSION" >> "$GITHUB_OUTPUT"
+            echo "new-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           else
-            echo "newversion=$VERSION_TYPE" >> "$GITHUB_OUTPUT"
+            echo "new-version=$VERSION_TYPE" >> "$GITHUB_OUTPUT"
           fi
         else
-          if [ -z "$NEWVERSION" ]; then
-            echo "Either version_type or newversion must be provided" >&2
+          if [ -z "$NEW_VERSION" ]; then
+            echo "Either version-type or new-version must be provided" >&2
             exit 1
           fi
-          echo "newversion=$NEWVERSION" >> "$GITHUB_OUTPUT"
+          echo "new-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
         fi
     - name: npm version
       shell: bash
       env:
-        NEWVERSION: ${{ steps.resolve_version.outputs.newversion }}
-        GITHUB_TOKEN: ${{ inputs.github_token }}
-      run: npm version "$NEWVERSION"
+        NEW_VERSION: ${{ steps['resolve-version'].outputs['new-version'] }}
+        GITHUB_TOKEN: ${{ inputs['github-token'] }}
+      run: npm version "$NEW_VERSION"
     - run: echo "release-tag=$(git describe --tags)" >> $GITHUB_OUTPUT
       id: release-tag-retreiver
       shell: bash
     - name: git push
       shell: bash
       run: |
-        if [ "${{ inputs.push_version_commit }}" = "true" ]; then
+        if [ "${{ inputs['push-version-commit'] }}" = "true" ]; then
           git push --follow-tags
         else
           echo "Skipping git push --follow-tags"
         fi
     - name: publish
       shell: bash
-      run: ${{ inputs.publish_cmd }}
+      run: ${{ inputs['publish-cmd'] }}
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
+        GH_TOKEN: ${{ inputs['github-token'] }}
+    - name: Update major version branch
+      if: ${{ inputs['major-branch'] == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        RELEASE_TAG="${{ steps['release-tag-retreiver'].outputs['release-tag'] }}"
+        # Strip leading v, extract major number, re-prefix
+        MAJOR=$(echo "$RELEASE_TAG" | sed 's/^v//' | cut -d. -f1)
+        if ! echo "$MAJOR" | grep -qE '^[0-9]+$'; then
+          echo "Could not parse major version from tag '$RELEASE_TAG'" >&2
+          exit 1
+        fi
+        MAJOR_BRANCH="v${MAJOR}"
+        COMMIT_SHA=$(git rev-parse HEAD)
+        echo "Pointing '$MAJOR_BRANCH' to $COMMIT_SHA"
+        git branch -f "$MAJOR_BRANCH" "$COMMIT_SHA"
+        git push origin "$MAJOR_BRANCH" --force


### PR DESCRIPTION
## Summary

- **New feature:** `major-branch` input — after each release, npm-bump creates or force-resets a floating major version branch (e.g. `v1`, `v2`, `v3`) and force-pushes it to origin. This is the mechanism that lets GitHub Actions consumers pin to a major version ref (`uses: you/action@v3`) and receive patch/minor updates automatically without manual re-pinning.
- **Breaking rename:** all action inputs and the output are now kebab-case to match GitHub Actions conventions (e.g. `version_type` → `version-type`, `newversion` → `new-version`, `release_tag` → `release-tag`).
- **npm-bump opts in:** the repo's own release workflow enables `major-branch: true` since npm-bump is itself a GitHub Action.

## What changed

### `action.yml`
- All inputs renamed to kebab-case: `git-email`, `git-username`, `version-type`, `new-version`, `push-version-commit`, `publish-cmd`, `github-token`
- New `major-branch` input (default `false`)
- Output renamed: `release_tag` → `release-tag`
- New "Update major version branch" step (runs only when `major-branch: true`): parses major version from release tag, uses `git branch -f` to create or force-reset the branch, then force-pushes to origin
- Internal env vars and step IDs updated to kebab/consistent naming

### `.github/workflows/release.yml`
- Dispatch inputs renamed to kebab-case (`version-type`, `new-version`)
- Action `with:` block updated to kebab-case input names
- `major-branch: true` added
- Output reference updated to `release-tag`

### `README.md`
- All input/output docs updated to kebab-case
- Usage example updated to `@v3` and kebab-case inputs
- FAQ stub for major version refs filled in with a working example
- Removed outdated advice to add `package-lock.json` to `.gitignore`

## Reviewer notes

- This is a **breaking change** for any consumer using the old underscore-style input names — they will need to update their `with:` blocks.
- The `major-branch` step uses `git branch -f <name> <sha>` which is idempotent: it creates the branch on first run and force-resets it on subsequent runs without needing an existence check.
- Force-pushing a major branch requires `contents: write` permission, which is already required for the version commit push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)